### PR TITLE
Fix: Prevent Auto-Unassignment When PR is Created Within 24 Hours

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -234,20 +234,29 @@ const run = async () => {
 
                     if (daysInactive > 1) {
                         console.log(`Unassigning issue #${event.issue.number} due to inactivity`);
-
                         try { 
-                          const query = `type:pr state:open repo:${owner}/${repoName} ${event.issue.number} in:body`;
-                          const pullRequests = await octokit.search.issuesAndPullRequests({ q: query });
+                          const timelineEvents = await octokit.paginate(octokit.issues.listEventsForTimeline, {
+                            owner,
+                            repo: repoName,
+                            issue_number: event.issue.number,
+                            per_page: 100,
+                          });
 
-                          if (pullRequests.data.total_count > 0) {
-                              console.log(`Issue #${event.issue.number} has an open pull request, skipping unassign.`);
-                              continue; // Skip unassigning if there's an open PR
+                          const hasOpenLinkedPR = timelineEvents.some(e =>
+                            e.event === "cross-referenced" &&
+                            e.source &&
+                            e.source.issue &&
+                            e.source.issue.pull_request &&
+                            e.source.issue.state === "open"
+                          );
+                          if (hasOpenLinkedPR) {
+                              console.log(`Issue #${event.issue.number} has an open pull request (cross-referenced), skipping unassign.`);
+                              continue; 
                           }
                         } catch (searchError) {
                           console.log(`Error checking for open pull requests for issue #${event.issue.number}:`, searchError);
                         }
-
-
+                        
                         const issueDetails = await octokit.issues.get({
                             owner,
                             repo: repoName,


### PR DESCRIPTION
Users were being automatically unassigned from issues after 24 hours of inactivity, even when they had created a pull request within the time limit. This was frustrating for contributors who completed their work on time but still got removed from the issue.

Solves: https://github.com/OWASP-BLT/BLT/issues/4618


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale-assignment behavior: before auto-unassigning an issue for inactivity, the system now checks for any open linked pull requests and skips unassignment if one exists. Errors during this check are handled gracefully so normal unassign flow continues when the check cannot confirm an open PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->