### PR TITLE
Refactor: Fix the search qualifiers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ const run = async () => {
                     for (const assignedIssue of assignedIssues) {
                         if (assignedIssue.number === issue.number) continue;
 
-                        const query = `type:pr state:open repo:${owner}/${repoName} ${assignedIssue.number} in:body`;
+                        const query = `repo:${owner}/${repoName} is:pr is:open ${assignedIssue.number} in:body`;
                         const pullRequests = await octokit.search.issuesAndPullRequests({ q: query });
 
                         if (pullRequests.data.total_count === 0) {


### PR DESCRIPTION
This PR addresses a follow-up issue mentioned in this [co-pilot conversation](https://github.com/OWASP-BLT/BLT-Action/pull/74#discussion_r2453265751). 

Fixes: https://github.com/OWASP-BLT/BLT/issues/4618


## Description
The query logic to structure the url query which has the old implementation, seems not to be working as expected.

The search.issuesAndPullRequests API doesn’t interpret type:pr and state:open correctly  it treats them as literal terms, not qualifiers.
This caused the query to always return zero results, leading the bot to think no open PR existed even when one did.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal search query formatting for improved pull request retrieval reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->