### PR TITLE
docs: fix singular wording for `/giphy` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ To use the `/giphy` command:
   - Makes the issue available for others
 
 #### Fun & Engagement Commands
-- **Post a GIF**: Comment `/giphy [search term]`
+  - **Post a GIF**: Comment `/giphy [search term]`
   - Example: `/giphy celebration`
   - Posts an animated GIF from Giphy matching your search term
   


### PR DESCRIPTION
Small documentation fix.
The `/giphy` command posts a single GIF per invocation, not multiple.

This PR updates the wording from **"Post GIFs"** to **"Post a GIF"** to reflect the actual behavior of the action.
No functional code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Minor formatting updates to documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->