### PR TITLE
Add PR-closed-assignee remove logic to be used by workflows

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -43822,7 +43822,7 @@ async function hasOpenLinkedPR(
 }
 
 async function getLinkedPRsWithDetails(octokit, owner, repoName, issueNumber) {
-    const allPRs = { open: [], closed: [] };
+    const allPRs = { open: [], closed: [], error: false };
     const currentRepo = `${owner}/${repoName}`;
     const seen = new Set();
 
@@ -43882,6 +43882,7 @@ async function getLinkedPRsWithDetails(octokit, owner, repoName, issueNumber) {
         } catch (err) {
             if (err.status !== 404) {
                 console.error(`Error fetching PR #${prNumber}:`, err?.status || err?.message);
+                allPRs.error = true;
             }
             continue;
         }
@@ -43910,11 +43911,27 @@ async function ensureClosedPRLabel(octokit, owner, repoName) {
     }
 }
 
-function extractLinkedIssuesFromPRBody(prBody) {
+function extractLinkedIssuesFromPRBody(prBody, currentOwner, currentRepo) {
     if (!prBody) return [];
-    const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)(?:\s*:\s*|\s+)(?:#(\d+)|https?:\/\/github\.com\/[^\/]+\/[^\/]+\/issues\/(\d+))/gi;
+    const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)(?:\s*:\s*|\s+)(?:#(\d+)|https?:\/\/github\.com\/([^\/]+)\/([^\/]+)\/issues\/(\d+))/gi;
     const matches = [...prBody.matchAll(regex)];
-    return [...new Set(matches.map(m => parseInt(m[1] || m[2])))];
+    const issues = [];
+    
+    for (const match of matches) {
+        if (match[1]) {
+            issues.push(parseInt(match[1]));
+        } else if (match[2] && match[3] && match[4]) {
+            const urlOwner = match[2];
+            const urlRepo = match[3];
+            const issueNumber = parseInt(match[4]);
+            
+            if (urlOwner === currentOwner && urlRepo === currentRepo) {
+                issues.push(issueNumber);
+            }
+        }
+    }
+    
+    return [...new Set(issues)];
 }
 
 async function findLinkedIssuesFromTimeline(octokit, owner, repoName, prNumber) {
@@ -43949,7 +43966,7 @@ async function handleClosedPR(octokit, owner, repoName, pr, attribution) {
     
     await ensureClosedPRLabel(octokit, owner, repoName);
     
-    const bodyIssues = extractLinkedIssuesFromPRBody(pr.body);
+    const bodyIssues = extractLinkedIssuesFromPRBody(pr.body, owner, repoName);
     const timelineIssues = await findLinkedIssuesFromTimeline(octokit, owner, repoName, pr.number);
     const linkedIssues = [...new Set([...bodyIssues, ...timelineIssues])];
     
@@ -44008,7 +44025,7 @@ async function handleClosedPR(octokit, owner, repoName, pr, attribution) {
 async function handleOpenedPR(octokit, owner, repoName, pr, attribution) {
     console.log(`PR #${pr.number} was opened by @${pr.user.login}`);
     
-    const bodyIssues = extractLinkedIssuesFromPRBody(pr.body);
+    const bodyIssues = extractLinkedIssuesFromPRBody(pr.body, owner, repoName);
     const timelineIssues = await findLinkedIssuesFromTimeline(octokit, owner, repoName, pr.number);
     const linkedIssues = [...new Set([...bodyIssues, ...timelineIssues])];
     


### PR DESCRIPTION
## Summary

Adds automated workflow to unassign contributors when their pull request is closed (not merged), with a 12-hour grace period to open a new PR.

## Problem

When a contributor's PR is closed, they remain assigned to the issue indefinitely. This blocks other contributors from picking up the issue.

## Solution

Integrates closed PR management directly into the BLT-Action code:

**On PR close (not merged):**

- Posts a warning comment

- Adds `pr-closed-pending-unassign` label

**On new PR open:**

- Cancels the warning

- Removes the label

**Every 12 hours (scheduled):**

- Checks labeled issues

- Unassigns contributors if no new PR was opened

## Changes

- Added `pull_request_target` event handling for closed/opened/reopened PRs

- Added 12-hour grace period enforcement to scheduled checks

- New helper functions for PR-issue linking and grace period management

- Reuses existing `hasOpenLinkedPR` function for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically detects issues linked to closed (non-merged) PRs, labels them as pending-unassign and posts a 12-hour warning before unassigning.
  * Opening/reopening a PR clears pending-unassign status, removes warnings, and notifies contributors.
  * Scheduled/manual enforcement scans pending items, cleans up labels/warnings, unassigns stale items, and notifies users.
  * Comment-based assignment/unassignment now verifies linked PR status and provides clearer takeover and error messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->