### PR TITLE
Fix `extractLinkedIssuesFromPRBody` regex to support the `Owner/Repo#IssueNumber` format used by GitHub Copilot PRs, preventing silent failures in the unassignment flow.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,7 @@ async function ensureClosedPRLabel(octokit, owner, repoName) {
 
 function extractLinkedIssuesFromPRBody(prBody, currentOwner, currentRepo) {
     if (!prBody) return [];
-    const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)(?:\s*:\s*|\s+)(?:(?:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+))?#(\d+)|https?:\/\/github\.com\/([^\/]+)\/([^\/]+)\/issues\/(\d+))/gi;
+    const regex = /(?<!\w)(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)(?:\s*:\s*|\s+)(?:(?:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+))?#(\d+)|https?:\/\/github\.com\/([^\/]+)\/([^\/]+)\/issues\/(\d+))/gi;
     const matches = [...prBody.matchAll(regex)];
     const issues = [];
     

--- a/src/index.js
+++ b/src/index.js
@@ -182,18 +182,27 @@ async function ensureClosedPRLabel(octokit, owner, repoName) {
 
 function extractLinkedIssuesFromPRBody(prBody, currentOwner, currentRepo) {
     if (!prBody) return [];
-    const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)(?:\s*:\s*|\s+)(?:#(\d+)|https?:\/\/github\.com\/([^\/]+)\/([^\/]+)\/issues\/(\d+))/gi;
+    const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)(?:\s*:\s*|\s+)(?:(?:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+))?#(\d+)|https?:\/\/github\.com\/([^\/]+)\/([^\/]+)\/issues\/(\d+))/gi;
     const matches = [...prBody.matchAll(regex)];
     const issues = [];
     
     for (const match of matches) {
-        if (match[1]) {
-            issues.push(parseInt(match[1]));
-        } else if (match[2] && match[3] && match[4]) {
-            const urlOwner = match[2];
-            const urlRepo = match[3];
-            const issueNumber = parseInt(match[4]);
-            
+        if (match[3]) {
+            const refOwner = match[1];
+            const refRepo = match[2];
+            const issueNumber = parseInt(match[3]);
+
+            if (refOwner && refRepo) {
+                if (refOwner.toLowerCase() === currentOwner.toLowerCase() && refRepo.toLowerCase() === currentRepo.toLowerCase()) {
+                    issues.push(issueNumber);
+                }
+            } else {
+                issues.push(issueNumber);
+            }
+        } else if (match[4] && match[5] && match[6]) {
+            const urlOwner = match[4];
+            const urlRepo = match[5];
+            const issueNumber = parseInt(match[6]);
             if (urlOwner === currentOwner && urlRepo === currentRepo) {
                 issues.push(issueNumber);
             }

--- a/src/index.js
+++ b/src/index.js
@@ -203,7 +203,8 @@ function extractLinkedIssuesFromPRBody(prBody, currentOwner, currentRepo) {
             const urlOwner = match[4];
             const urlRepo = match[5];
             const issueNumber = parseInt(match[6]);
-            if (urlOwner === currentOwner && urlRepo === currentRepo) {
+            if (urlOwner.toLowerCase() === currentOwner.toLowerCase() &&
+                urlRepo.toLowerCase() === currentRepo.toLowerCase()) {
                 issues.push(issueNumber);
             }
         }

--- a/src/mock-test.js
+++ b/src/mock-test.js
@@ -43,10 +43,10 @@ async function postGiphyComment(owner, repo, issueNumber, searchText, giphyApiKe
 
 async function postTipComment(owner, repo, issueNumber, receiver, amount) {
   const sponsorUrl = `https://github.com/sponsors/${receiver}`;
-  
+
   // Check if GitHub Sponsors is enabled
   await axios.head(sponsorUrl);
-  
+
   const url = `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments`;
   const response = await axios.post(url, {
     body: `💰 **Tip Request from @sender to @${receiver}**\n\nAmount: **$${amount}**\n\nTo complete this tip, please visit @${receiver}'s GitHub Sponsors page and select a one-time payment:\n\n🔗 [Sponsor @${receiver}](${sponsorUrl})\n\n*Note: GitHub Sponsors does not support automated payments via API. Please complete the transaction manually by selecting "One-time" on the sponsor page and entering your desired amount.*`
@@ -229,10 +229,10 @@ describe('GitHub API Mock Test', () => {
 
     const githubScope = nock('https://api.github.com')
       .post(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, (body) => {
-        return body.body.includes('Tip Request') && 
-               body.body.includes(`@${receiver}`) && 
-               body.body.includes(`$${amount}`) &&
-               body.body.includes(`https://github.com/sponsors/${receiver}`);
+        return body.body.includes('Tip Request') &&
+          body.body.includes(`@${receiver}`) &&
+          body.body.includes(`$${amount}`) &&
+          body.body.includes(`https://github.com/sponsors/${receiver}`);
       })
       .reply(201, { status: 'success' });
 
@@ -452,11 +452,11 @@ describe('GitHub API Mock Test', () => {
 
   describe('Human commenter guard for /assign and /unassign', () => {
     function isHumanCommenter(comment) {
-        return (
-            comment &&
-            comment.user &&
-            (comment.user.type === 'User' || comment.user.type === 'Mannequin')
-        );
+      return (
+        comment &&
+        comment.user &&
+        (comment.user.type === 'User' || comment.user.type === 'Mannequin')
+      );
     }
 
     const assignKeywords = [
@@ -551,39 +551,7 @@ describe('GitHub API Mock Test', () => {
   });
 
   describe('Extract Linked Issue from PR Body', () => {
-    // Re-implement the function here for unit testing (mirrors src/index.js)
-    function extractLinkedIssuesFromPRBody(prBody, currentOwner, currentRepo) {
-      if (!prBody) return [];
-      const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)(?:\s*:\s*|\s+)(?:(?:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+))?#(\d+)|https?:\/\/github\.com\/([^\/]+)\/([^\/]+)\/issues\/(\d+))/gi;
-      const matches = [...prBody.matchAll(regex)];
-      const issues = [];
-
-      for (const match of matches) {
-        if (match[3]) {
-          const refOwner = match[1];
-          const refRepo = match[2];
-          const issueNumber = parseInt(match[3]);
-
-          if (refOwner && refRepo) {
-            if (refOwner.toLowerCase() === currentOwner.toLowerCase() && refRepo.toLowerCase() === currentRepo.toLowerCase()) {
-              issues.push(issueNumber);
-            }
-          } else {
-            issues.push(issueNumber);
-          }
-        } else if (match[4] && match[5] && match[6]) {
-          const urlOwner = match[4];
-          const urlRepo = match[5];
-          const issueNumber = parseInt(match[6]);
-
-          if (urlOwner === currentOwner && urlRepo === currentRepo) {
-            issues.push(issueNumber);
-          }
-        }
-      }
-
-      return [...new Set(issues)];
-    }
+    const { extractLinkedIssuesFromPRBody } = require('./index.js');
 
     it('parses plain "Fixes #123" format', () => {
       const body = 'This PR fixes a bug.\n\nFixes #3753';
@@ -611,6 +579,12 @@ describe('GitHub API Mock Test', () => {
 
     it('handles case-insensitive owner/repo matching', () => {
       const body = 'Fixes owasp-blt/blt#3753';
+      const result = extractLinkedIssuesFromPRBody(body, 'OWASP-BLT', 'BLT');
+      assert.deepStrictEqual(result, [3753]);
+    });
+
+    it('handles case-insensitive URL matching', () => {
+      const body = 'Fixes https://github.com/owasp-blt/blt/issues/3753';
       const result = extractLinkedIssuesFromPRBody(body, 'OWASP-BLT', 'BLT');
       assert.deepStrictEqual(result, [3753]);
     });


### PR DESCRIPTION
Fixes #110 

### Overview
Fix `extractLinkedIssuesFromPRBody` regex to support the `Owner/Repo#IssueNumber` format used by GitHub Copilot PRs, preventing silent failures in the unassignment flow.

**Context:**
When Copilot opens a PR linking an issue via `Fixes Owner/Repo#123`, `BLT-Action` failed to detect the linked issue because the regex only supported `#123` and full URL formats. This caused the action to skip its unassignment logic entirely, leaving Copilot permanently assigned to issues when PRs were closed without merging (real-world case: PR OWASP-BLT/BLT#4969 → Issue OWASP-BLT/BLT#3753).

### Key Features
- **Regex Enhancement** → Extended the regex in `extractLinkedIssuesFromPRBody` to capture the optional `Owner/Repo` prefix before `#IssueNumber`
- **Cross-repo Filtering** → Added case-insensitive owner/repo comparison so that `Owner/Repo#123` references from different repositories are correctly rejected
- **Comprehensive Test Suite** → Added 9 new unit tests covering all issue-linking formats, edge cases, and a real Copilot PR body reproduction

### Technical Changes

#### Code Architecture
The regex capture groups were restructured from 4 to 6 groups to accommodate the new `Owner/Repo#N` format. The matching logic now has a three-way branch:
1. `#N` or `Owner/Repo#N` → captured via groups 1-3 (owner/repo optional)
2. Full GitHub URL → captured via groups 4-6
3. Cross-repo filtering uses **case-insensitive** comparison for `Owner/Repo#N` format

#### Files Modified
- **Core Logic:**
  - `src/index.js` - Updated regex pattern and refactored match-group handling to support all three issue-linking formats with proper cross-repo filtering
- **Tests:**
  - `src/mock-test.js` - Added `Extract Linked Issue from PR Body` test suite with 9 test cases covering: plain `#N`, `Owner/Repo#N` (Copilot style), full URL, cross-repo rejection, case-insensitive matching, null/empty body, deduplication, real Copilot PR body (PR #4969), and multiple keyword variations

### Impact Assessment
- **Performance:** +114 / -8 lines across 2 files; no runtime performance impact
- **Security:** No security changes
- **User Impact:** Copilot (and other bots using `Owner/Repo#N` format) will now be correctly unassigned from issues when their PRs are closed without merging — previously they remained permanently assigned
- **Developer Impact:** No API changes; the function signature and return type remain identical


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced extraction of linked issues from PR descriptions: supports repo-local refs, owner/repo-prefixed refs, and full issue URLs with case-insensitive matching and proper deduplication.

* **Tests**
  * Added comprehensive tests for varied PR-body formats including local refs, cross-repo links, full URLs, case variations, duplicates, empty/null bodies, and real-world PR scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->