### PR TITLE
Potential fix for code scanning alert no. 8: Server-side request forgery

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1103,6 +1103,18 @@ const run = async () => {
                         return;
                     }
 
+                    // Validate receiver (GitHub username) to prevent malformed URLs
+                    const usernamePattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+                    if (!usernamePattern.test(receiver)) {
+                        await octokit.issues.createComment({
+                            owner,
+                            repo: repoName,
+                            issue_number: issue ? issue.number : pull_request.number,
+                            body: `⚠️ \`${receiver}\` does not appear to be a valid GitHub username. Please check the username and try again.${attribution}`
+                        });
+                        return;
+                    }
+
                     const amountValue = amountMatch[1];
                     const sponsorUrl = `https://github.com/sponsors/${receiver}`;
 


### PR DESCRIPTION
Potential fix for [https://github.com/OWASP-BLT/BLT-Action/security/code-scanning/8](https://github.com/OWASP-BLT/BLT-Action/security/code-scanning/8)

In general, to fix SSRF issues you must ensure that user input cannot arbitrarily control the URL of outgoing HTTP requests. This usually involves (1) fixing the scheme and hostname, chosen from a server‑side allow‑list, and (2) strictly validating or mapping any user‑controlled components (like path segments or query parameters) against expected formats. Inputs that do not pass validation should be rejected or sanitized before being used to construct the URL.

For this specific code, the hostname `github.com` is already fixed and safe. The remaining issue is that `receiver`, derived from a free‑form `/tip` command, is used directly as the path segment in `/sponsors/${receiver}`. The safest and least intrusive fix is to validate `receiver` against GitHub’s username rules, or at least against a conservative regular expression that only allows typical username characters and length. If `receiver` fails validation, we should not make the outbound request; instead, reply with an error comment indicating the username is invalid. This preserves existing functionality for valid usernames while preventing malformed or malicious values from influencing the request.

Concretely, within `src/index.js` in the `/tip` handling block:

1. Introduce a small validation step after `const receiver = ...` and amount validation, before building `sponsorUrl`. Implement a regex such as `/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/` which is a conservative approximation of GitHub username rules (start/end with alphanumeric, optional internal hyphens, max length 39).
2. If `receiver` does not match, post a GitHub comment explaining that the username appears invalid and abort processing.
3. If it does match, proceed as before: build `sponsorUrl` with the validated `receiver` and call `axios.head(sponsorUrl, ...)`.

This requires no new imports or external packages; the existing file already uses regular expressions for `amount`, so adding another regex is consistent. All changes are localized to the shown code around lines 1088–1110.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation for the /tip command’s recipient field. Malformed or invalid usernames now trigger a clear warning comment on the related issue or pull request and halt tip processing to prevent incorrect tip creation. This reduces failed or misdirected tips and provides immediate feedback so users can correct recipient names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->