### PR TITLE
Docs: add command usage examples for better clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,41 @@ To use the `/giphy` command:
     
     ```
 
-
 ### Usage
+
+## Command Examples
+
+### Assigning an Issue
+
+`/assign`
+
+or
+
+`assign to me`
+
+---
+
+### Unassigning Yourself
+
+`/unassign`
+
+---
+
+### Posting a GIF
+
+`/giphy celebration`
+
+---
+
+### Sending Kudos
+
+`/kudos @username great work!`
+
+---
+
+### Sending a Tip
+
+`/tip @username $10`
 
 #### Assignment Commands
 - **Self-assign to an issue**: Comment any of these on an issue:

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ or
 ##### Sending a Tip
 
 `/tip @username $10`
+
 ---
 
 #### Assignment Commands

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ To use the `/giphy` command:
 
 ### Usage
 
-## Command Examples
+#### Command Examples
 
-### Assigning an Issue
+##### Assigning an Issue
 
 `/assign`
 
@@ -164,27 +164,28 @@ or
 
 ---
 
-### Unassigning Yourself
+##### Unassigning Yourself
 
 `/unassign`
 
 ---
 
-### Posting a GIF
+##### Posting a GIF
 
 `/giphy celebration`
 
 ---
 
-### Sending Kudos
+##### Sending Kudos
 
 `/kudos @username great work!`
 
 ---
 
-### Sending a Tip
+##### Sending a Tip
 
 `/tip @username $10`
+---
 
 #### Assignment Commands
 - **Self-assign to an issue**: Comment any of these on an issue:

--- a/dist/index.js
+++ b/dist/index.js
@@ -43925,19 +43925,29 @@ async function ensureClosedPRLabel(octokit, owner, repoName) {
 
 function extractLinkedIssuesFromPRBody(prBody, currentOwner, currentRepo) {
     if (!prBody) return [];
-    const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)(?:\s*:\s*|\s+)(?:#(\d+)|https?:\/\/github\.com\/([^\/]+)\/([^\/]+)\/issues\/(\d+))/gi;
+    const regex = /(?<!\w)(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)(?:\s*:\s*|\s+)(?:(?:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+))?#(\d+)|https?:\/\/github\.com\/([^\/]+)\/([^\/]+)\/issues\/(\d+))/gi;
     const matches = [...prBody.matchAll(regex)];
     const issues = [];
     
     for (const match of matches) {
-        if (match[1]) {
-            issues.push(parseInt(match[1]));
-        } else if (match[2] && match[3] && match[4]) {
-            const urlOwner = match[2];
-            const urlRepo = match[3];
-            const issueNumber = parseInt(match[4]);
-            
-            if (urlOwner === currentOwner && urlRepo === currentRepo) {
+        if (match[3]) {
+            const refOwner = match[1];
+            const refRepo = match[2];
+            const issueNumber = parseInt(match[3]);
+
+            if (refOwner && refRepo) {
+                if (refOwner.toLowerCase() === currentOwner.toLowerCase() && refRepo.toLowerCase() === currentRepo.toLowerCase()) {
+                    issues.push(issueNumber);
+                }
+            } else {
+                issues.push(issueNumber);
+            }
+        } else if (match[4] && match[5] && match[6]) {
+            const urlOwner = match[4];
+            const urlRepo = match[5];
+            const issueNumber = parseInt(match[6]);
+            if (urlOwner.toLowerCase() === currentOwner.toLowerCase() &&
+                urlRepo.toLowerCase() === currentRepo.toLowerCase()) {
                 issues.push(issueNumber);
             }
         }


### PR DESCRIPTION
This PR improves the README by adding a dedicated "Command Examples" section.

Changes:
- Added examples for /assign, /unassign, /giphy, /kudos, and /tip commands
- Improves usability and onboarding for new contributors

Please let me know if any changes are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Command Examples" section to the README with concrete, easy-to-follow examples and subsections for self-assignment (/assign, “assign to me”), self-unassignment (/unassign), GIF posting (/giphy celebration), sending kudos (/kudos @username great work!), and tipping (/tip @username $10). Includes delimiter lines and clear usage samples to help users run commands confidently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->